### PR TITLE
Fix Out/out_rel which were inverted

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ p1 = ET.Person | g | run                  # add an entity to the graph
 </div>
 
 ```python
-p1 | Out[RT.FirstName]         # one hop: step onto the relation
+p1 | out_rel[RT.FirstName]   # one hop: step onto the relation
 
-p1 | out_rel[RT.FirstName]     # two hops: step onto the target
+p1 | Out[RT.FirstName]       # two hops: step onto the target
 ```
 
 <br />
@@ -145,9 +145,9 @@ p1 | out_rel[RT.FirstName]     # two hops: step onto the target
 </div>
 
 ```python
-p1 | time_travel[-2]                                           # move reference frame back two time slices
+p1 | time_travel[-2]                                        # move reference frame back two time slices
 
-p1 | time_travel[Time('2021 December 4 15:31:00 (+0100)')]     # move to a specific date and time
+p1 | time_travel[Time('2023 January 1 12:34:56 (+0100)')]   # move to a specific date and time
 ```
 
 <br />


### PR DESCRIPTION
The README.md said that `Out` was one hop and `out_rel` was two hops, but (unless I'm mistaken) it's the opposite, so this PR fixes that.

One additional issue is that the **Get started** section looks like code that you can try out, but it doesn't actually work all the way:

* `p1 = p1 | now` is missing before traversing the graph, so `p1 | out_rel[RT.FirstName]` fails.
* `p1 | Out[RT.FirstName]` is missing `| value | collect` to actually get the first name
* more generally, users won't get a useful result without `| collect`
* the `time_travel[Time('...')]` example only works if the date is valid, might be worth noting

I can fix these issues as well, if you want?